### PR TITLE
fix: alias of require.resolve

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -216,6 +216,7 @@ var overlay =
 		: {
 				send: function send() {}
 			};
+/* Rspack dev server runtime client */
 var onSocketMessage = {
 	hot: function hot() {
 		if (parsedResourceQuery.hot === "false") {

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,4 +1,5 @@
-const RESOLVER_MAP: Record<string, typeof require.resolve> = {};
+const Module = require("module");
+const RESOLVER_MAP: Record<string, typeof Module._resolveFilename> = {};
 export const addResolveAlias = (
 	name: string,
 	aliasMap: Record<string, string>
@@ -7,17 +8,13 @@ export const addResolveAlias = (
 	if (RESOLVER_MAP[modulePath]) {
 		throw new Error(`Should not add resolve alias to ${name} again.`);
 	}
-	const m = require.cache[modulePath];
-	if (!m) {
-		throw new Error("Failed to resolve webpack-dev-server.");
-	}
-	RESOLVER_MAP[modulePath] = m.require.resolve;
-	m.require.resolve = ((id: string, options?: any) =>
-		aliasMap[id] ||
-		RESOLVER_MAP[modulePath]!.apply(m.require, [
-			id,
-			options
-		])) as typeof require.resolve;
+	RESOLVER_MAP[modulePath] = Module._resolveFilename;
+	Module._resolveFilename = Module._resolveFilename = (request: string, mod: NodeModule, ...args: unknown[]) => {
+			if (mod.filename === modulePath && aliasMap[request]) {
+				return aliasMap[request];
+			}
+			return RESOLVER_MAP[modulePath](request, mod, ...args);
+	};
 };
 
 export const removeResolveAlias = (name: string) => {
@@ -30,7 +27,7 @@ export const removeResolveAlias = (name: string) => {
 		throw new Error("Failed to resolve webpack-dev-server");
 	}
 	if (RESOLVER_MAP[modulePath]) {
-		m.require.resolve = RESOLVER_MAP[modulePath]!;
+		Module._resolveFilename = RESOLVER_MAP[modulePath]!;
 		delete RESOLVER_MAP[modulePath];
 	}
 };

--- a/tests/e2e/__snapshots__/client.test.js.snap.webpack5
+++ b/tests/e2e/__snapshots__/client.test.js.snap.webpack5
@@ -6,6 +6,12 @@ exports[`client option configure client entry should disable client entry: page 
 
 exports[`client option configure client entry should disable client entry: response status 1`] = `200`;
 
+exports[`client option configure client entry should redirect client entry to rspack: console messages 1`] = `[]`;
+
+exports[`client option configure client entry should redirect client entry to rspack: page errors 1`] = `[]`;
+
+exports[`client option configure client entry should redirect client entry to rspack: response status 1`] = `200`;
+
 exports[`client option default behaviour responds with a 200 status code for /ws path: console messages 1`] = `[]`;
 
 exports[`client option default behaviour responds with a 200 status code for /ws path: page errors 1`] = `[]`;


### PR DESCRIPTION
Should not just override the `require.resolve` because node will create a [new require](https://github.com/nodejs/node/blob/main/lib/internal/modules/helpers.js#L129-L171) for module executing. So need to override the [Module._resolveFilename](https://github.com/nodejs/node/blob/main/eslint.config.mjs#L28-L37) just like node eslint does.