### PR TITLE
fix: align engines range with `webpack-dev-server`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "dist",
     "client"
   ],
+  "engines": {
+    "node": ">= 18.12.0"
+  },
   "packageManager": "pnpm@9.6.0",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack-dev-server/issues",


### PR DESCRIPTION
Align the engines range with `webpack-dev-server`, see https://github.com/webpack/webpack-dev-server/blob/master/package.json#L23C1-L25C5