### PR TITLE
fix: handle undefined hash in socket message handler

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -243,7 +243,7 @@ var onSocketMessage = {
 		sendMessage("Invalid");
 	},
 	/**
-	 * @param {string | undefined} hash
+	 * @param {string | undefined} _hash
 	 */
 	hash: function hash(_hash) {
 		if (!_hash) {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -243,9 +243,13 @@ var onSocketMessage = {
 		sendMessage("Invalid");
 	},
 	/**
-	 * @param {string} hash
+	 * @param {string | undefined} hash
 	 */
 	hash: function hash(_hash) {
+		if (!_hash) {
+			return;
+		}
+
 		status.previousHash = status.currentHash;
 		status.currentHash = _hash;
 	},


### PR DESCRIPTION
## What
Fixed handling of undefined hash values received from rspack during hot module reload.

## Why
When rspack sends an undefined hash through WebSocket messages, it causes a TypeError when trying to use indexOf on the undefined value. This happens in the following sequence:

1. Run the dev-server

2. Visit the page

3. Rspack triggers a HMR and for some reason returns an empty hash

4. The hash is handled and when triggering a `reloadApp` the `currentHash` is `undefined`

## How
Added propert handling for `undefined` hash values in the hot update handler to prevent the TypeError.

## Notes
I've used `--no-verify` for the commit as the file contains pre-existing style inconsistencies that are outside the scope of this fix.

## Screenshots

![The messages sent from Rspack via the WebSocket showing a type hash without data](https://github.com/user-attachments/assets/b9d848d4-f223-41d6-b9e9-85536fc98f0e)
The messages sent from Rspack via the WebSocket showing a type hash without data

![The error thrown and catched with react-refresh of `reloadApp` trying to call `currentHash.indexOf(/** @type {string} */ previousHash) >= 0`
](https://github.com/user-attachments/assets/64a0408f-2e14-4c7f-a82b-86873546d480)
The error thrown and catched with react-refresh of `reloadApp` trying to call `currentHash.indexOf(/** @type {string} */ previousHash) >= 0`

