### PR TITLE
fix: "Overlay enabled" false positive

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -192,7 +192,7 @@ if (parsedResourceQuery.overlay) {
 
 		decodeOverlayOptions(options.overlay);
 	}
-	enabledFeatures.Overlay = true;
+	enabledFeatures.Overlay = options.overlay !== false;
 }
 
 if (parsedResourceQuery.logging) {


### PR DESCRIPTION
When `client.overlay` is set to `false` the resource query string will be contain `overlay=false` ([relevant code](https://github.com/webpack/webpack-dev-server/blob/1e6c003efaadb41189087f784d3be09e43a4bbea/lib/Server.js#L764-L778)). This PR fixes the `enabledFeatures` logic to handle cases when `overlay=false`

Equivalent `webpack-dev-server` PR: https://github.com/webpack/webpack-dev-server/pull/5464