### PR TITLE
chore(workflow): enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,23 +37,20 @@ on:
         default: false
 
 permissions:
+  contents: write
   # To publish packages with provenance
   id-token: write
 
 jobs:
   release:
     name: Release
-    permissions:
-      contents: write
-      # To publish packages with provenance
-      id-token: write
     runs-on: ubuntu-latest
-
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Pnpm
+      - name: Setup Pnpm
         run: |
           npm install -g corepack@latest
           corepack enable
@@ -63,6 +60,12 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
+
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install Dependencies
         run: pnpm install
@@ -76,6 +79,3 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           TAG: ${{ inputs.tag }}
           VERSION: ${{ inputs.version }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "types": "./dist/index.d.ts",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
-    "provenance": true
+    "registry": "https://registry.npmjs.org/"
   },
   "exports": {
     ".": {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -7,7 +7,6 @@ import { inc } from "semver";
 const RELEASE_TAG = process.env.TAG || "beta";
 const RELEASE_DRY_RUN = process.env.DRY_RUN || "true";
 const RELEASE_VERSION_TYPE = process.env.VERSION || "prerelease";
-const RELEASE_NPM_TOKEN = process.env.NPM_TOKEN || "";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const PKG_PATH = path.resolve(__dirname, "../package.json");
@@ -26,14 +25,6 @@ console.info(`Release ${RELEASE_TAG} version ${nextVersion}`);
 console.info(`Updating version from ${currentVersion} to ${nextVersion}`);
 pkg.version = nextVersion;
 fs.writeJsonSync(PKG_PATH, pkg, { spaces: 2 });
-
-// Write npmrc
-const npmrcPath = `${process.env.HOME}/.npmrc`;
-console.info(`Writing npmrc to ${npmrcPath}`);
-fs.writeFileSync(
-	npmrcPath,
-	`//registry.npmjs.org/:_authToken=${RELEASE_NPM_TOKEN}`,
-);
 
 // Publish to npm
 console.info(`Publishing to npm with tag ${RELEASE_TAG}`);


### PR DESCRIPTION
## Summary

Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

## Related Links

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
