### PR TITLE
chore: remove npmrc cleanup in release script

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -36,7 +36,6 @@ try {
 	console.error(`Publish failed: ${e.message}`);
 	process.exit(1);
 } finally {
-	fs.removeSync(npmrcPath);
 }
 
 // Push tag to github


### PR DESCRIPTION
Fix a bug that was introduced in https://github.com/web-infra-dev/rspack-dev-server/pull/45