### PR TITLE
feat(deps): upgrade http-proxy-middleware to v4.0.0-beta.2

### DIFF
--- a/docs/migrate-v1-to-v2.md
+++ b/docs/migrate-v1-to-v2.md
@@ -18,9 +18,9 @@ The minimum supported Node.js version is now `^20.19.0 || >=22.12.0`.
 
 `@rspack/dev-server` is now published as **pure ESM** package.
 
-### Upgraded `http-proxy-middleware` to v3
+### Upgraded `http-proxy-middleware` to v4
 
-`http-proxy-middleware` has been updated to v3, which has some breaking changes:
+`http-proxy-middleware` has been updated to v4, which has some breaking changes:
 
 - `proxy[].path` is removed. Use `pathFilter` (or `context`) instead.
 
@@ -55,7 +55,7 @@ The minimum supported Node.js version is now `^20.19.0 || >=22.12.0`.
   - When `bypass` was used and that function returned a boolean, it would automatically result in a 404 request. This can’t be achieved in a similar way now, or, if it returned a string, you can do what was done in the example above.
   - `bypass` also allowed sending data; this can no longer be done. If you really need to do it, you’d have to create a new route in the proxy that sends the same data, or alternatively create a new route on the main server and, following the example above, send the data you wanted.
 
-> Refer to the [http-proxy-middleware v3 migration guide](https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md) for details.
+> Refer to the [http-proxy-middleware v3 breaking changes](https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md#v3-breaking-changes) for details.
 
 ### Default app now uses `connect-next`
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "hono": "^4.12.9",
     "http-compression": "^1.1.2",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^4.0.0-beta.2",
     "ipaddr.js": "^2.3.0",
     "launch-editor": "^2.13.2",
     "nano-staged": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,10 +74,10 @@ importers:
         version: 1.1.2
       http-proxy:
         specifier: ^1.18.1
-        version: 1.18.1(debug@4.4.3)
+        version: 1.18.1
       http-proxy-middleware:
-        specifier: ^3.0.5
-        version: 3.0.5
+        specifier: ^4.0.0-beta.2
+        version: 4.0.0-beta.2
       ipaddr.js:
         specifier: ^2.3.0
         version: 2.3.0
@@ -701,9 +701,6 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.17':
-    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
-
   '@types/mime-types@3.0.1':
     resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
 
@@ -1171,9 +1168,9 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@3.0.5:
-    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@4.0.0-beta.2:
+    resolution: {integrity: sha512-ELwx+by6D9k8hOdSTC2YdzygA5NqHBow2nO/GPlT4kCuBPDTBBm3WU8fLtabwnE63rdiI4FKRzlEjyTkVkDIQA==}
+    engines: {node: ^22.12.0 || >=24.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -1182,6 +1179,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.0:
+    resolution: {integrity: sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2345,10 +2345,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/http-proxy@1.17.17':
-    dependencies:
-      '@types/node': 24.12.0
-
   '@types/mime-types@3.0.1': {}
 
   '@types/node@24.12.0':
@@ -2720,9 +2716,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.15.11(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
+  follow-redirects@1.15.11: {}
 
   forwarded@0.2.0: {}
 
@@ -2801,21 +2795,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@4.0.0-beta.2:
     dependencies:
-      '@types/http-proxy': 1.17.17
       debug: 4.4.3
-      http-proxy: 1.18.1(debug@4.4.3)
+      httpxy: 0.5.0
       is-glob: 4.0.3
       is-plain-object: 5.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.3):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -2826,6 +2819,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.0: {}
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `http-proxy-middleware` in `@rsbuild/core` from `^3.0.5` to `^4.0.0-beta.2`, which brings in the upstream `httpxy` refactor.
- Update the upgrade guide to describe the v4 upgrade.

## Related Links

- https://github.com/chimurai/http-proxy-middleware/pull/1160
- https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0-beta.2
- https://github.com/chimurai/http-proxy-middleware/releases