### PR TITLE
chore: fix lint issues

### DIFF
--- a/client-src/index.ts
+++ b/client-src/index.ts
@@ -8,10 +8,8 @@
  * https://github.com/webpack/webpack-dev-server/blob/main/LICENSE
  */
 
-// @ts-expect-error: No type definitions available for '@rspack/core/hot/emitter.js'
 import { emitter as hotEmitter } from '@rspack/core/hot/emitter.js';
-// @ts-expect-error: No type definitions available for '@rspack/core/hot/log.js'
-import { log as webpackHotLog } from '@rspack/core/hot/log.js';
+import { log as rspackHotLog } from '@rspack/core/hot/log.js';
 import { createOverlay, formatProblem } from './overlay.js';
 import socket from './socket.js';
 import { defineProgressElement, isProgressSupported } from './progress.js';
@@ -191,7 +189,7 @@ if (typeof parsedResourceQuery.reconnect !== 'undefined') {
 
 const setAllLogLevel = (level: LogLevel): void => {
   // This is needed because the HMR logger operate separately from dev server logger
-  webpackHotLog.setLogLevel(
+  rspackHotLog.setLogLevel(
     level === 'verbose' || level === 'log' ? 'info' : (level as LogLevel),
   );
   setLogLevel(level);

--- a/client-src/modules/logger/Logger.ts
+++ b/client-src/modules/logger/Logger.ts
@@ -24,15 +24,9 @@ class WebpackLogger {
   private [LOG_SYMBOL]: (type: LogTypeEnum, args?: Args) => void;
   private [TIMERS_SYMBOL]: TimersMap = new Map();
   private [TIMERS_AGGREGATES_SYMBOL]: TimersMap = new Map();
-  // @ts-ignore
-  private getChildLogger: (name: string | (() => string)) => WebpackLogger;
 
-  constructor(
-    log: (type: LogTypeEnum, args?: Args) => void,
-    getChildLogger: (name: string | (() => string)) => WebpackLogger,
-  ) {
+  constructor(log: (type: LogTypeEnum, args?: Args) => void) {
     this[LOG_SYMBOL] = log;
-    this.getChildLogger = getChildLogger;
   }
 
   error(...args: Args) {

--- a/client-src/modules/logger/Logger.ts
+++ b/client-src/modules/logger/Logger.ts
@@ -16,11 +16,11 @@ import {
   type TimersMap,
 } from '../types.js';
 
-const LOG_SYMBOL = Symbol('webpack logger raw log method');
-const TIMERS_SYMBOL = Symbol('webpack logger times');
-const TIMERS_AGGREGATES_SYMBOL = Symbol('webpack logger aggregated times');
+const LOG_SYMBOL = Symbol('rspack logger raw log method');
+const TIMERS_SYMBOL = Symbol('rspack logger times');
+const TIMERS_AGGREGATES_SYMBOL = Symbol('rspack logger aggregated times');
 
-class WebpackLogger {
+class RspackLogger {
   private [LOG_SYMBOL]: (type: LogTypeEnum, args?: Args) => void;
   private [TIMERS_SYMBOL]: TimersMap = new Map();
   private [TIMERS_AGGREGATES_SYMBOL]: TimersMap = new Map();
@@ -95,7 +95,7 @@ class WebpackLogger {
   timeLog(label?: string) {
     const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
     if (!prev) {
-      throw new Error(`No such label '${label}' for WebpackLogger.timeLog()`);
+      throw new Error(`No such label '${label}' for RspackLogger.timeLog()`);
     }
     const time = process.hrtime(prev);
     this[LOG_SYMBOL](LogType.time, [label, ...time]);
@@ -104,7 +104,7 @@ class WebpackLogger {
   timeEnd(label?: string) {
     const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
     if (!prev) {
-      throw new Error(`No such label '${label}' for WebpackLogger.timeEnd()`);
+      throw new Error(`No such label '${label}' for RspackLogger.timeEnd()`);
     }
     const time = process.hrtime(prev);
     /** @type {TimersMap} */
@@ -116,7 +116,7 @@ class WebpackLogger {
     const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
     if (!prev) {
       throw new Error(
-        `No such label '${label}' for WebpackLogger.timeAggregate()`,
+        `No such label '${label}' for RspackLogger.timeAggregate()`,
       );
     }
     const time = process.hrtime(prev);
@@ -145,4 +145,4 @@ class WebpackLogger {
   }
 }
 
-export { WebpackLogger as Logger };
+export { RspackLogger as Logger };

--- a/client-src/modules/logger/index.ts
+++ b/client-src/modules/logger/index.ts
@@ -15,10 +15,12 @@ import type { LoggerOptions } from '../types.js';
 /**
  * Client stub for tapable SyncBailHook
  */
-function SyncBailHook() {
-  return {
-    call() {},
-  };
+class SyncBailHook {
+  constructor(_args?: string[]) {}
+
+  call(_origin?: string, _type?: string, _args?: unknown) {
+    return undefined;
+  }
 }
 
 const currentDefaultLoggerOptions = {
@@ -35,17 +37,13 @@ const configureDefaultLogger = (options: LoggerOptions): void => {
 };
 
 const getLogger = (name: string): Logger =>
-  new Logger(
-    (type, args) => {
-      if (hooks.log.call(name, type, args) === undefined) {
-        currentDefaultLogger(name, type, args);
-      }
-    },
-    (childName) => getLogger(`${name}/${childName}`),
-  );
+  new Logger((type, args) => {
+    if (hooks.log.call(name, type, args) === undefined) {
+      currentDefaultLogger(name, type, args);
+    }
+  });
 
 const hooks = {
-  // @ts-ignore
   log: new SyncBailHook(['origin', 'type', 'args']),
 };
 

--- a/client-src/rspack-hot.d.ts
+++ b/client-src/rspack-hot.d.ts
@@ -1,0 +1,11 @@
+declare module '@rspack/core/hot/emitter.js' {
+  export const emitter: {
+    emit(eventName: string, ...args: unknown[]): void;
+  };
+}
+
+declare module '@rspack/core/hot/log.js' {
+  export const log: {
+    setLogLevel(level: string | boolean): void;
+  };
+}

--- a/client-src/utils/ansiHTML.ts
+++ b/client-src/utils/ansiHTML.ts
@@ -138,8 +138,7 @@ export default function ansiHTML(text: string) {
   const ansiCodes: string[] = [];
   // Replace with markup.
   let ret = text.replace(
-    //@ts-ignore TS1487 error
-    /\033\[(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?m/g,
+    /\x1b\[(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?m/g,
     (m) => {
       const match = m.match(/(;?\d+)/g)?.map(normalizeSeq) as unknown as Match;
       Object.defineProperty(match, 'advance', {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1183,7 +1183,7 @@ class Server<
   #getClientTransport() {
     let clientImplementation: string | undefined;
     let clientImplementationFound = true;
-    let clientTransport =
+    const clientTransport =
       typeof this.options.client === 'object' &&
       this.options.client !== null &&
       typeof this.options.client.webSocketTransport !== 'undefined'

--- a/tests/normalizeOptions.test.ts
+++ b/tests/normalizeOptions.test.ts
@@ -112,7 +112,6 @@ async function match(config: RspackOptions) {
   );
   await server.start();
   // it will break ci
-  //@ts-ignore
   server.options.port = undefined;
   expect(server.options).toMatchSnapshot();
   await server.stop();
@@ -146,8 +145,7 @@ async function getAdditionEntries(
   // some hack for snapshot
   const value = Object.fromEntries(
     Object.entries(entries).map(([key, item]) => {
-      // @ts-expect-error
-      const replaced = item.import?.map((entry) => {
+      const replaced = (item as { import?: string[] }).import?.map((entry) => {
         const array = entry
           .replace(/\\/g, '/')
           .replace(/port=\d+/g, '')


### PR DESCRIPTION
## Summary

This PR fixes the current lint failures by replacing `ts-comment` suppressions with typed alternatives, adding a minimal local declaration for the rspack hot modules, and removing the unused `getChildLogger` plumbing.

## Testing

- `pnpm lint`
- `pnpm build`

## Related Links

- None