### PR TITLE
feat(deps)!: bump http-proxy-middleware to 4.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "hono": "^4.12.14",
     "http-compression": "^1.1.3",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "4.0.0-beta.3",
     "ipaddr.js": "^2.3.0",
     "launch-editor": "^2.13.2",
     "nano-staged": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,10 +74,10 @@ importers:
         version: 1.1.3
       http-proxy:
         specifier: ^1.18.1
-        version: 1.18.1(debug@4.4.3)
+        version: 1.18.1
       http-proxy-middleware:
-        specifier: ^3.0.5
-        version: 3.0.5
+        specifier: 4.0.0-beta.3
+        version: 4.0.0-beta.3
       ipaddr.js:
         specifier: ^2.3.0
         version: 2.3.0
@@ -698,9 +698,6 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.17':
-    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
-
   '@types/mime-types@3.0.1':
     resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
 
@@ -1166,9 +1163,9 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@3.0.5:
-    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@4.0.0-beta.3:
+    resolution: {integrity: sha512-wxwujnPix6nWzqhZg7d6OEyhELLUwWMGpJOcHveX95/5q8sIOV9viOEYg8ersC3SfTiX3FNT2Ju2u7EDxOtfdw==}
+    engines: {node: ^22.12.0 || >=24.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -1177,6 +1174,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.0:
+    resolution: {integrity: sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1246,9 +1246,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2351,10 +2351,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/http-proxy@1.17.17':
-    dependencies:
-      '@types/node': 24.12.2
-
   '@types/mime-types@3.0.1': {}
 
   '@types/node@24.12.2':
@@ -2726,9 +2722,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.15.11(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
+  follow-redirects@1.15.11: {}
 
   forwarded@0.2.0: {}
 
@@ -2805,21 +2799,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@4.0.0-beta.3:
     dependencies:
-      '@types/http-proxy': 1.17.17
       debug: 4.4.3
-      http-proxy: 1.18.1(debug@4.4.3)
+      httpxy: 0.5.0
       is-glob: 4.0.3
-      is-plain-object: 5.0.0
+      is-plain-obj: 4.1.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.3):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -2830,6 +2823,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -2876,7 +2871,7 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-plain-object@5.0.0: {}
+  is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 

--- a/tests/e2e/allowed-hosts.test.js
+++ b/tests/e2e/allowed-hosts.test.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const { rspack } = require('@rspack/core');
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const {
+  createProxyMiddleware,
+  proxyEventsPlugin,
+} = require('http-proxy-middleware');
 const { RspackDevServer: Server } = require('@rspack/dev-server');
 const config = require('../fixtures/client-config/rspack.config');
 const runBrowser = require('../helpers/run-browser');
@@ -327,14 +330,30 @@ describe('allowed hosts', () => {
 
       function startProxy(callback) {
         const app = express();
+        const hostHeader = `[${devServerHost}]:${devServerPort}`;
+        const setProxyHost = (proxyReq) => {
+          proxyReq.setHeader('host', hostHeader);
+        };
 
         app.use(
           '/',
           createProxyMiddleware({
-            target: `http://[${devServerHost}]:${devServerPort}`,
+            // http-proxy-middleware v4 fails on IPv6 string targets like
+            // "http://[::1]:port". Use a structured target, then restore the
+            // correct Host header for both HTTP and WS requests.
+            target: {
+              protocol: 'http:',
+              hostname: devServerHost,
+              port: devServerPort,
+            },
             ws: true,
             changeOrigin: true,
-            logger: console,
+            ejectPlugins: true,
+            plugins: [proxyEventsPlugin],
+            on: {
+              proxyReq: setProxyHost,
+              proxyReqWs: setProxyHost,
+            },
           }),
         );
 


### PR DESCRIPTION
## Summary
- upgrade `http-proxy-middleware` to `4.0.0-beta.3`
- keep the IPv6 `allowed-hosts` websocket test exercising `http-proxy-middleware` by switching that proxy setup to the minimal v4-compatible configuration

## Related Links
- https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0-beta.3
