### PR TITLE
fix: bundle ws types in declarations

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
       syntax: 'es2023',
       dts: {
         bundle: {
-          bundledPackages: ['chokidar', 'readdirp', 'connect-next', 'ws'],
+          bundledPackages: [
+            'chokidar',
+            'readdirp',
+            'connect-next',
+            'ws',
+            '@types/ws',
+          ],
         },
       },
       source: {


### PR DESCRIPTION
## Summary

This PR makes the generated public declaration file self-contained for the `ws` types exposed by `@rspack/dev-server`. It bundles `@types/ws` during dts generation so consumers can typecheck the package without installing `ws` or `@types/ws` themselves.


Fixes #206