### PR TITLE
chore: update peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ws": "^8.21.0"
   },
   "peerDependencies": {
-    "@rspack/core": "^2.0.0-0",
+    "@rspack/core": "^2.0.0",
     "selfsigned": "^5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

This PR updates peer dependency ranges that still use the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). It keeps the existing compatibility alternatives where present and does not change runtime code.