### PR TITLE
chore: remove finalhandler workaround for http2

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1568,26 +1568,6 @@ class Server<
       },
     });
 
-    const isHTTP2 =
-      (this.options.server as ServerConfiguration<A, S>).type === 'http2';
-
-    if (isHTTP2) {
-      // TODO patch for https://github.com/pillarjs/finalhandler/pull/45, need remove then will be resolved
-      middlewares.push({
-        name: 'http2-status-message-patch',
-        middleware: (_req: Request, res: Response, next: NextFunction) => {
-          Object.defineProperty(res, 'statusMessage', {
-            get() {
-              return '';
-            },
-            set() {},
-          });
-
-          next();
-        },
-      });
-    }
-
     // compress is placed last and uses unshift so that it will be the first middleware used
     if (this.options.compress) {
       middlewares.push({


### PR DESCRIPTION
The workaround here is not needed since yall are pulling in finalhandler 2.x line, which landed the [fix in v2.0.0](https://github.com/pillarjs/finalhandler/blob/master/HISTORY.md#v200--2024-09-02) ([PR 53](https://github.com/pillarjs/finalhandler/pull/53/changes#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R280))