### PR TITLE
fix: address lint CI failures

### DIFF
--- a/client-src/overlay.ts
+++ b/client-src/overlay.ts
@@ -13,7 +13,8 @@
 
 import ansiHTML from './utils/ansiHTML.js';
 
-const getCodePoint = !!String.prototype.codePointAt
+const hasCodePointAt = typeof String.prototype.codePointAt === 'function';
+const getCodePoint = hasCodePointAt
   ? (input: string, position: number): number | undefined =>
       input.codePointAt(position)
   : (input: string, position: number): number | undefined =>

--- a/client-src/utils/ansiHTML.ts
+++ b/client-src/utils/ansiHTML.ts
@@ -20,6 +20,7 @@ type Match = {
 
 // Reference to https://github.com/sindresorhus/ansi-regex
 const _regANSI =
+  // eslint-disable-next-line no-control-regex
   /(?:(?:\u001b\[)|\u009b)(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\u001b[A-M]/;
 
 const _defColors: Record<string, string | Array<string>> = {
@@ -138,6 +139,7 @@ export default function ansiHTML(text: string) {
   const ansiCodes: string[] = [];
   // Replace with markup.
   let ret = text.replace(
+    // eslint-disable-next-line no-control-regex
     /\x1b\[(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?m/g,
     (m) => {
       const match = m.match(/(;?\d+)/g)?.map(normalizeSeq) as unknown as Match;
@@ -211,7 +213,9 @@ ansiHTML.setColors = (colors: typeof _defColors) => {
 
   const _finalColors: typeof _defColors = {};
   for (const key in _defColors) {
-    let hex = colors.hasOwnProperty(key) ? colors[key] : null;
+    let hex = Object.prototype.hasOwnProperty.call(colors, key)
+      ? colors[key]
+      : null;
     if (!hex) {
       _finalColors[key] = _defColors[key];
       continue;


### PR DESCRIPTION
## Summary

This PR fixes the current main lint CI failures after the rslint upgrade with a minimal diff. It keeps the existing ANSI regex implementation and adds localized `no-control-regex` disables for those literals, removes the redundant boolean cast around the `codePointAt` capability check, and uses `Object.prototype.hasOwnProperty.call` for color overrides.

## Related Links

- https://github.com/rstackjs/rspack-dev-server/pull/234