### PR TITLE
test: stabilize target worker e2e

### DIFF
--- a/tests/e2e/target.test.js
+++ b/tests/e2e/target.test.js
@@ -7,8 +7,32 @@ const port = require('../helpers/ports-map').target;
 const workerConfig = require('../fixtures/worker-config/rspack.config');
 const workerConfigDevServerFalse = require('../fixtures/worker-config-dev-server-false/rspack.config');
 
+const workerConsoleMessages = [
+  "Worker said: I'm working before postMessage",
+  'Worker said: Message sent: message',
+];
+
 const sortByTerm = (data, term) =>
-  data.sort((a, b) => (a.indexOf(term) < b.indexOf(term) ? -1 : 1));
+  data.sort((a, b) => {
+    const aHasTerm = a.includes(term);
+    const bHasTerm = b.includes(term);
+
+    if (aHasTerm === bHasTerm) {
+      return 0;
+    }
+
+    return aHasTerm ? 1 : -1;
+  });
+
+const waitForWorkerConsoleMessages = async (consoleMessages) => {
+  await expect
+    .poll(() =>
+      consoleMessages
+        .map((message) => message.text())
+        .filter((message) => message.startsWith('Worker said:')),
+    )
+    .toEqual(workerConsoleMessages);
+};
 
 describe('target', () => {
   const targets = [
@@ -115,6 +139,8 @@ describe('target', () => {
         waitUntil: 'networkidle0',
       });
 
+      await waitForWorkerConsoleMessages(consoleMessages);
+
       expect(
         sortByTerm(
           consoleMessages.map((message) => message.text()),
@@ -163,6 +189,8 @@ describe('target', () => {
       await page.goto(`http://127.0.0.1:${port}/`, {
         waitUntil: 'networkidle0',
       });
+
+      await waitForWorkerConsoleMessages(consoleMessages);
 
       expect(
         sortByTerm(


### PR DESCRIPTION
## Summary

This PR fixes a Windows CI flaky failure in the target e2e test. The test asserted console snapshots right after `networkidle0`, but worker `postMessage` logs can arrive slightly later, so the snapshot sometimes missed both `Worker said` messages. It now polls for the worker messages before snapshotting and keeps the final console snapshot order stable.

## Related Links

- https://github.com/rstackjs/rspack-dev-server/actions/runs/27898462982/job/82554282758?pr=235