### PR TITLE
chore: release v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/dev-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Development server for Rspack",
   "homepage": "https://github.com/rstackjs/rspack-dev-server",
   "bugs": "https://github.com/rstackjs/rspack-dev-server/issues",


### PR DESCRIPTION
This PR bumps `@rspack/dev-server` to `2.2.1` for the next patch release.